### PR TITLE
Store table partitions metadata in a separate table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GCP Census retrieves BigQuery metadata using [REST API](https://cloud.google.com
 1. Daily run is triggered by GAE cron (see [cron.yaml](config/cron.yaml) for exact details)
 1. GCP Census iterates over all projects/datasets/tables to which it has access
 1. A task is created for each table and queued for execution in GAE Task Queue
-1. Task worker retrieves [Table metadata](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables) and streams it into [bigquery.table_metadata](bq_schemas/bigquery/table_metadata_v0_1.json) table. In case of partitioned tables, GCP Census retrieves also [partitions summary](https://cloud.google.com/bigquery/docs/creating-partitioned-tables#listing_partitions_in_a_table) by querying the partitioned table
+1. Task worker retrieves [Table metadata](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables) and streams it into [bigquery.table_metadata](bq_schemas/bigquery/table_metadata_v1_0.json) table. In case of partitioned tables, GCP Census retrieves also [partitions summary](https://cloud.google.com/bigquery/docs/creating-partitioned-tables#listing_partitions_in_a_table) by querying the partitioned table and stores metadata in [bigquery.partition_metadata](bq_schemas/bigquery/partition_metadata_v1_0.json) table 
 1. User can query metadata using BigQuery UI/API
 1. Optionally you can create a Data Studio dashboard based on metadata
 

--- a/bq_schemas/bigquery/partition_metadata_v1_0.json
+++ b/bq_schemas/bigquery/partition_metadata_v1_0.json
@@ -1,0 +1,113 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "snapshotTime",
+        "type": "TIMESTAMP",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "projectId",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "datasetId",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "tableId",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "partitionId",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "creationTime",
+        "type": "TIMESTAMP",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "lastModifiedTime",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "location",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "numBytes",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "numLongTermBytes",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "numRows",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "timePartitioning",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "expirationMs",
+            "type": "INTEGER",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "type",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "type",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "json",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "description",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "labels",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      }
+    ]
+  },
+  "timePartitioning": {
+    "type": "DAY"
+  }
+}

--- a/bq_schemas/bigquery/table_metadata_v1_0.json
+++ b/bq_schemas/bigquery/table_metadata_v1_0.json
@@ -1,0 +1,108 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "snapshotTime",
+        "type": "TIMESTAMP",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "projectId",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "datasetId",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "tableId",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "creationTime",
+        "type": "TIMESTAMP",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "lastModifiedTime",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "location",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "numBytes",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "numLongTermBytes",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "numRows",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "timePartitioning",
+        "type": "RECORD",
+        "mode": "NULLABLE",
+        "fields": [
+          {
+            "name": "expirationMs",
+            "type": "INTEGER",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "type",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      },
+      {
+        "name": "type",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "json",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "description",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "labels",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "key",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "value",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          }
+        ]
+      }
+    ]
+  },
+  "timePartitioning": {
+    "type": "DAY"
+  }
+}

--- a/config/queue.yaml
+++ b/config/queue.yaml
@@ -22,3 +22,10 @@ queue:
   retry_parameters:
     task_retry_limit: 5
     task_age_limit: 6h
+- name: bigquery-partitions
+  rate: 100/s
+  max_concurrent_requests: 100
+  bucket_size: 100
+  retry_parameters:
+    task_retry_limit: 5
+    task_age_limit: 6h

--- a/gcp_census/bigquery/bigquery_client.py
+++ b/gcp_census/bigquery/bigquery_client.py
@@ -119,17 +119,12 @@ class BigQuery(object): # pylint: disable=R0904
             body=query_data).execute(num_retries=3)
 
     @retry(HttpError, tries=6, delay=2, backoff=2)
-    def get_table(self, project_id, dataset_id, table_id, log_table=True):
+    def get_table(self, project_id, dataset_id, table_id):
         try:
             table = self.service.tables().get(
                 projectId=project_id, datasetId=dataset_id, tableId=table_id
             ).execute(num_retries=3)
 
-            if log_table and table:
-                table_copy = table.copy()
-                if 'schema' in table_copy:
-                    del table_copy['schema']
-                logging.info("Table: " + json.dumps(table_copy))
             return table
         except HttpError as error:
             logging.info('Can\'t fetch table: %s', error.resp)

--- a/gcp_census/bigquery/bigquery_table_metadata.py
+++ b/gcp_census/bigquery/bigquery_table_metadata.py
@@ -22,3 +22,16 @@ class BigQueryTableMetadata(object):
 
         return False
 
+    def is_partition(self):
+        table_id = self.big_query_table['tableReference']['tableId']
+        return '$' in table_id
+
+    def get_partition_id(self):
+        assert self.is_partition() == True
+        table_id = self.big_query_table['tableReference']['tableId']
+        return table_id.split('$')[1]
+
+    def get_table_id(self):
+        table_id = self.big_query_table['tableReference']['tableId']
+        return table_id.split('$')[0]
+

--- a/gcp_census/bigquery/bigquery_table_metadata.py
+++ b/gcp_census/bigquery/bigquery_table_metadata.py
@@ -9,8 +9,7 @@ class BigQueryTableMetadata(object):
 
     def is_daily_partitioned(self):
         if self.big_query_table and 'timePartitioning' in self.big_query_table:
-            table_id = self.big_query_table['tableReference']['tableId']
-            if '$' in table_id:
+            if self.is_partition():
                 return False
             time_partitioning = self.big_query_table['timePartitioning']
             if 'type' in time_partitioning:

--- a/gcp_census/bigquery/bigquery_table_metadata.py
+++ b/gcp_census/bigquery/bigquery_table_metadata.py
@@ -1,36 +1,37 @@
 import logging
+
 from types import NoneType
 
 
 class BigQueryTableMetadata(object):
-    def __init__(self, big_query_table):
-        assert isinstance(big_query_table, (dict, NoneType))
-        self.big_query_table = big_query_table
+    def __init__(self, table):
+        assert isinstance(table, (dict, NoneType))
+        self.table = table
 
     def is_daily_partitioned(self):
-        if self.big_query_table and 'timePartitioning' in self.big_query_table:
+        if self.table and 'timePartitioning' in self.table:
             if self.is_partition():
                 return False
-            time_partitioning = self.big_query_table['timePartitioning']
+            time_partitioning = self.table['timePartitioning']
             if 'type' in time_partitioning:
                 type_of_partitioning = time_partitioning['type']
                 if type_of_partitioning == 'DAY':
                     return True
             logging.error("Table metadata has different structure than "
-                          "expected: %s", self.big_query_table)
+                          "expected: %s", self.table)
 
         return False
 
     def is_partition(self):
-        table_id = self.big_query_table['tableReference']['tableId']
+        table_id = self.table['tableReference']['tableId']
         return '$' in table_id
 
     def get_partition_id(self):
         assert self.is_partition() == True
-        table_id = self.big_query_table['tableReference']['tableId']
+        table_id = self.table['tableReference']['tableId']
         return table_id.split('$')[1]
 
     def get_table_id(self):
-        table_id = self.big_query_table['tableReference']['tableId']
+        table_id = self.table['tableReference']['tableId']
         return table_id.split('$')[0]
 

--- a/gcp_census/bigquery/bigquery_table_streamer.py
+++ b/gcp_census/bigquery/bigquery_table_streamer.py
@@ -1,6 +1,8 @@
 import datetime
 
 from gcp_census.bigquery.row import Row
+from gcp_census.bigquery.transformers.partition_metadata_v1_0 import \
+    PartitionMetadataV1_0
 from gcp_census.bigquery.transformers.table_metadata_v0_1 import \
     TableMetadataV0_1
 from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
@@ -12,10 +14,11 @@ class BigQueryTableStreamer(object):
         self.big_query = big_query
 
     def stream_metadata(self, table_metadata, table_partitions):
-        self.__stream(TableMetadataV0_1(table_metadata, table_partitions))
-        self.__stream(TableMetadataV1_0(table_metadata))
         if table_metadata.is_partition():
+            self.__stream(PartitionMetadataV1_0(table_metadata))
+        else:
             self.__stream(TableMetadataV1_0(table_metadata))
+            self.__stream(TableMetadataV0_1(table_metadata, table_partitions))
 
     def __stream(self, transformer):
         row = Row(dataset_id="bigquery",

--- a/gcp_census/bigquery/bigquery_table_streamer.py
+++ b/gcp_census/bigquery/bigquery_table_streamer.py
@@ -1,34 +1,37 @@
+import datetime
+
 from gcp_census.bigquery.row import Row
 from gcp_census.bigquery.transformers.table_metadata_v0_1 import \
     TableMetadataV0_1
 from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
     TableMetadataV1_0
-import datetime
 
 
 class BigQueryTableStreamer(object):
     def __init__(self, big_query):
         self.big_query = big_query
 
-    def stream_metadata(self, table, table_partitions):
-        self.__stream(TableMetadataV0_1(table, table_partitions))
-        self.__stream(TableMetadataV1_0(table))
+    def stream_metadata(self, table_metadata, table_partitions):
+        self.__stream(TableMetadataV0_1(table_metadata, table_partitions))
+        self.__stream(TableMetadataV1_0(table_metadata))
+        if table_metadata.is_partition():
+            self.__stream(TableMetadataV1_0(table_metadata))
 
     def __stream(self, transformer):
         row = Row(dataset_id="bigquery",
                   table_id=transformer.target_table_id,
-                  insert_id=self.__create_insert_id(transformer.table,
+                  insert_id=self.__create_insert_id(transformer.table_metadata,
                                                     transformer.target_table_id),
                   data=transformer.transform())
         self.big_query.stream_stats(row)
 
     @staticmethod
-    def __create_insert_id(table, target_table_id):
+    def __create_insert_id(table_metadata, target_table_id):
         date = datetime.datetime.utcnow().strftime("%Y%m%d")
         insert_id = "{}/{}/{}/{}/{}".format(
             target_table_id,
-            table['tableReference']['projectId'],
-            table['tableReference']['datasetId'],
-            table['tableReference']['tableId'],
+            table_metadata.table['tableReference']['projectId'],
+            table_metadata.table['tableReference']['datasetId'],
+            table_metadata.table['tableReference']['tableId'],
             date)
         return insert_id

--- a/gcp_census/bigquery/bigquery_table_streamer.py
+++ b/gcp_census/bigquery/bigquery_table_streamer.py
@@ -1,0 +1,34 @@
+from gcp_census.bigquery.row import Row
+from gcp_census.bigquery.transformers.table_metadata_v0_1 import \
+    TableMetadataV0_1
+from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
+    TableMetadataV1_0
+import datetime
+
+
+class BigQueryTableStreamer(object):
+    def __init__(self, big_query):
+        self.big_query = big_query
+
+    def stream_metadata(self, table, table_partitions):
+        self.__stream(TableMetadataV0_1(table, table_partitions))
+        self.__stream(TableMetadataV1_0(table))
+
+    def __stream(self, transformer):
+        row = Row(dataset_id="bigquery",
+                  table_id=transformer.target_table_id,
+                  insert_id=self.__create_insert_id(transformer.table,
+                                                    transformer.target_table_id),
+                  data=transformer.transform())
+        self.big_query.stream_stats(row)
+
+    @staticmethod
+    def __create_insert_id(table, table_id):
+        date = datetime.datetime.utcnow().strftime("%Y%m%d")
+        insert_id = "{}/{}/{}/{}/{}".format(
+            table_id,
+            table['tableReference']['projectId'],
+            table['tableReference']['datasetId'],
+            table['tableReference']['tableId'],
+            date)
+        return insert_id

--- a/gcp_census/bigquery/bigquery_table_streamer.py
+++ b/gcp_census/bigquery/bigquery_table_streamer.py
@@ -23,10 +23,10 @@ class BigQueryTableStreamer(object):
         self.big_query.stream_stats(row)
 
     @staticmethod
-    def __create_insert_id(table, table_id):
+    def __create_insert_id(table, target_table_id):
         date = datetime.datetime.utcnow().strftime("%Y%m%d")
         insert_id = "{}/{}/{}/{}/{}".format(
-            table_id,
+            target_table_id,
             table['tableReference']['projectId'],
             table['tableReference']['datasetId'],
             table['tableReference']['tableId'],

--- a/gcp_census/bigquery/bigquery_task.py
+++ b/gcp_census/bigquery/bigquery_task.py
@@ -1,7 +1,6 @@
 import logging
 
 from datetime import datetime
-
 from google.appengine.api.taskqueue import Task
 
 from gcp_census.bigquery.bigquery_table_metadata import BigQueryTableMetadata
@@ -69,12 +68,12 @@ class BigQueryTask(object):
                                                       dataset_id,
                                                       table_id,
                                                       partitions)
-            self.table_streamer.stream_metadata(table, partitions)
+            self.table_streamer.stream_metadata(table_metadata, partitions)
 
     def create_partition_tasks(self, project_id, dataset_id, table_id,
                                partitions):
         for partition_id in partitions:
-            partitioned_table_id = "%s$%s".format(table_id, partition_id)
+            partitioned_table_id = "{}${}".format(table_id, partition_id)
             yield self.create_table_tasks(project_id, dataset_id,
                                           partitioned_table_id)
 

--- a/gcp_census/bigquery/bigquery_task.py
+++ b/gcp_census/bigquery/bigquery_task.py
@@ -54,7 +54,7 @@ class BigQueryTask(object):
                                          partitions):
         tasks = self.create_partition_tasks(project_id, dataset_id, table_id,
                                             partitions)
-        Tasks.schedule(queue_name='bigquery-tables', tasks=tasks)
+        Tasks.schedule(queue_name='bigquery-partitions', tasks=tasks)
 
     def stream_table_metadata(self, project_id, dataset_id, table_id):
         table = self.big_query.get_table(project_id, dataset_id, table_id)

--- a/gcp_census/bigquery/bigquery_task.py
+++ b/gcp_census/bigquery/bigquery_task.py
@@ -72,8 +72,8 @@ class BigQueryTask(object):
 
     def create_partition_tasks(self, project_id, dataset_id, table_id,
                                partitions):
-        table_id_list = ["{}${}".format(table_id, partition_id)
-                         for partition_id in partitions]
+        table_id_list = ["{}${}".format(table_id, partition['partitionId'])
+                         for partition in partitions]
         return self.create_table_tasks(project_id, dataset_id, table_id_list)
 
     @staticmethod

--- a/gcp_census/bigquery/bigquery_task.py
+++ b/gcp_census/bigquery/bigquery_task.py
@@ -72,10 +72,9 @@ class BigQueryTask(object):
 
     def create_partition_tasks(self, project_id, dataset_id, table_id,
                                partitions):
-        for partition_id in partitions:
-            partitioned_table_id = "{}${}".format(table_id, partition_id)
-            yield self.create_table_tasks(project_id, dataset_id,
-                                          partitioned_table_id)
+        table_id_list = ["{}${}".format(table_id, partition_id)
+                         for partition_id in partitions]
+        return self.create_table_tasks(project_id, dataset_id, table_id_list)
 
     @staticmethod
     def create_project_tasks(project_id_list):

--- a/gcp_census/bigquery/transformers/partition_metadata_v1_0.py
+++ b/gcp_census/bigquery/transformers/partition_metadata_v1_0.py
@@ -1,0 +1,14 @@
+from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
+    TableMetadataV1_0
+
+
+class PartitionMetadataV1_0(TableMetadataV1_0):
+    def __init__(self, table_metadata):
+        super(PartitionMetadataV1_0, self).__init__(table_metadata)
+        self.table_metadata = table_metadata
+        self.target_table_id = 'table_metadata_v1_0'
+
+    def transform(self):
+        data = super(PartitionMetadataV1_0, self).transform()
+        data['partitionId'] = self.table_metadata.get_partition_id()
+        return data

--- a/gcp_census/bigquery/transformers/partition_metadata_v1_0.py
+++ b/gcp_census/bigquery/transformers/partition_metadata_v1_0.py
@@ -6,7 +6,7 @@ class PartitionMetadataV1_0(TableMetadataV1_0):
     def __init__(self, table_metadata):
         super(PartitionMetadataV1_0, self).__init__(table_metadata)
         self.table_metadata = table_metadata
-        self.target_table_id = 'table_metadata_v1_0'
+        self.target_table_id = 'partition_metadata_v1_0'
 
     def transform(self):
         data = super(PartitionMetadataV1_0, self).transform()

--- a/gcp_census/bigquery/transformers/table_metadata_v0_1.py
+++ b/gcp_census/bigquery/transformers/table_metadata_v0_1.py
@@ -3,34 +3,35 @@ import time
 
 
 class TableMetadataV0_1(object):
-    def __init__(self, table, partitions=None):
-        self.table = table
+    def __init__(self, table_metadata, partitions=None):
+        self.table_metadata = table_metadata
         self.partitions = [] if partitions is None else partitions
         self.target_table_id = 'table_metadata_v0_1'
 
     def transform(self):
+        table = self.table_metadata.table
         return {
             'snapshotTime': time.time(),
-            'projectId': self.table['tableReference']['projectId'],
-            'datasetId': self.table['tableReference']['datasetId'],
-            'tableId': self.table['tableReference']['tableId'],
-            'creationTime': float(self.table['creationTime']) / 1000.0,
-            'lastModifiedTime': float(self.table['lastModifiedTime'])
+            'projectId': table['tableReference']['projectId'],
+            'datasetId': table['tableReference']['datasetId'],
+            'tableId': table['tableReference']['tableId'],
+            'creationTime': float(table['creationTime']) / 1000.0,
+            'lastModifiedTime': float(table['lastModifiedTime'])
                                 / 1000.0,
             'partition': self.partitions,
-            'location': self.table['location']
-            if 'location' in self.table else None,
-            'numBytes': self.table['numBytes'],
-            'numLongTermBytes': self.table['numLongTermBytes'],
-            'numRows': self.table['numRows'],
-            'timePartitioning': self.table[
+            'location': table['location']
+            if 'location' in table else None,
+            'numBytes': table['numBytes'],
+            'numLongTermBytes': table['numLongTermBytes'],
+            'numRows': table['numRows'],
+            'timePartitioning': table[
                 'timePartitioning'] if 'timePartitioning'
-                                       in self.table else None,
-            'type': self.table['type'],
-            'json': json.dumps(self.table),
-            'description': self.table['description']
-            if 'description' in self.table else None,
+                                       in table else None,
+            'type': table['type'],
+            'json': json.dumps(table),
+            'description': table['description']
+            if 'description' in table else None,
             'labels': [{'key': key, 'value': value} for key, value
-                       in self.table['labels'].iteritems()]
-            if 'labels' in self.table else []
+                       in table['labels'].iteritems()]
+            if 'labels' in table else []
         }

--- a/gcp_census/bigquery/transformers/table_metadata_v1_0.py
+++ b/gcp_census/bigquery/transformers/table_metadata_v1_0.py
@@ -3,32 +3,33 @@ import time
 
 
 class TableMetadataV1_0(object):
-    def __init__(self, table):
-        self.table = table
+    def __init__(self, table_metadata):
+        self.table_metadata = table_metadata
         self.target_table_id = 'table_metadata_v1_0'
 
     def transform(self):
+        table = self.table_metadata.table
         return {
             'snapshotTime': time.time(),
-            'projectId': self.table['tableReference']['projectId'],
-            'datasetId': self.table['tableReference']['datasetId'],
-            'tableId': self.table['tableReference']['tableId'],
-            'creationTime': float(self.table['creationTime']) / 1000.0,
-            'lastModifiedTime': float(self.table['lastModifiedTime'])
+            'projectId': table['tableReference']['projectId'],
+            'datasetId': table['tableReference']['datasetId'],
+            'tableId': self.table_metadata.get_table_id(),
+            'creationTime': float(table['creationTime']) / 1000.0,
+            'lastModifiedTime': float(table['lastModifiedTime'])
                                 / 1000.0,
-            'location': self.table['location']
-            if 'location' in self.table else None,
-            'numBytes': self.table['numBytes'],
-            'numLongTermBytes': self.table['numLongTermBytes'],
-            'numRows': self.table['numRows'],
-            'timePartitioning': self.table[
+            'location': table['location']
+            if 'location' in table else None,
+            'numBytes': table['numBytes'],
+            'numLongTermBytes': table['numLongTermBytes'],
+            'numRows': table['numRows'],
+            'timePartitioning': table[
                 'timePartitioning'] if 'timePartitioning'
-                                       in self.table else None,
-            'type': self.table['type'],
-            'json': json.dumps(self.table),
-            'description': self.table['description']
-            if 'description' in self.table else None,
+                                       in table else None,
+            'type': table['type'],
+            'json': json.dumps(table),
+            'description': table['description']
+            if 'description' in table else None,
             'labels': [{'key': key, 'value': value} for key, value
-                       in self.table['labels'].iteritems()]
-            if 'labels' in self.table else []
+                       in table['labels'].iteritems()]
+            if 'labels' in table else []
         }

--- a/gcp_census/bigquery/transformers/table_metadata_v1_0.py
+++ b/gcp_census/bigquery/transformers/table_metadata_v1_0.py
@@ -2,11 +2,10 @@ import json
 import time
 
 
-class TableMetadataV0_1(object):
-    def __init__(self, table, partitions=None):
+class TableMetadataV1_0(object):
+    def __init__(self, table):
         self.table = table
-        self.partitions = [] if partitions is None else partitions
-        self.target_table_id = 'table_metadata_v0_1'
+        self.target_table_id = 'table_metadata_v1_0'
 
     def transform(self):
         return {
@@ -17,7 +16,6 @@ class TableMetadataV0_1(object):
             'creationTime': float(self.table['creationTime']) / 1000.0,
             'lastModifiedTime': float(self.table['lastModifiedTime'])
                                 / 1000.0,
-            'partition': self.partitions,
             'location': self.table['location']
             if 'location' in self.table else None,
             'numBytes': self.table['numBytes'],

--- a/tests/bigquery_handler_test.py
+++ b/tests/bigquery_handler_test.py
@@ -276,3 +276,7 @@ class TestGcpMetadataHandler(unittest.TestCase):
         # then
         get_table.assert_called_once_with('myproject123', 'd1', 't1')
         self.assertEqual(stream_stats.call_count, 2)
+        tasks = self.taskqueue_stub.get_filtered_tasks()
+        self.assertEqual(len(tasks), 2)
+        self.assertEqual(tasks[0].url, '/bigQuery/project/myproject123/dataset/d1/table/t1$20171001')
+        self.assertEqual(tasks[1].url, '/bigQuery/project/myproject123/dataset/d1/table/t1$20171002')

--- a/tests/bigquery_handler_test.py
+++ b/tests/bigquery_handler_test.py
@@ -71,7 +71,8 @@ class TestGcpMetadataHandler(unittest.TestCase):
 
         # then
         list_project_ids.assert_called_once()
-        tasks = self.taskqueue_stub.get_filtered_tasks()
+        tasks = self.taskqueue_stub.get_filtered_tasks(
+            queue_names='bigquery-list')
         self.assertEqual(len(tasks), 3)
         self.assertEqual(tasks[0].url, '/bigQuery/project/p1')
         self.assertEqual(tasks[1].url, '/bigQuery/project/p2')
@@ -89,7 +90,8 @@ class TestGcpMetadataHandler(unittest.TestCase):
 
         # then
         list_dataset_ids.assert_called_once_with('myproject123')
-        tasks = self.taskqueue_stub.get_filtered_tasks()
+        tasks = self.taskqueue_stub.get_filtered_tasks(
+            queue_names='bigquery-list')
         self.assertEqual(len(tasks), 2)
         self.assertEqual(tasks[0].url,
                          '/bigQuery/project/myproject123/dataset/d1')
@@ -194,7 +196,8 @@ class TestGcpMetadataHandler(unittest.TestCase):
         # then
         list_tables.assert_called_once_with('myproject123', 'd1',
                                             page_token='abc123')
-        table_tasks = self.taskqueue_stub.get_filtered_tasks()
+        table_tasks = self.taskqueue_stub.get_filtered_tasks(
+            queue_names='bigquery-tables')
         self.assertEqual(len(table_tasks), 3)
         self.assertEqual(table_tasks[0].url,
                          '/bigQuery/project/myproject123/'
@@ -276,7 +279,7 @@ class TestGcpMetadataHandler(unittest.TestCase):
         # then
         get_table.assert_called_once_with('myproject123', 'd1', 't1')
         self.assertEqual(stream_stats.call_count, 2)
-        tasks = self.taskqueue_stub.get_filtered_tasks()
+        tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='bigquery-partitions')
         self.assertEqual(len(tasks), 2)
         self.assertEqual(tasks[0].url, '/bigQuery/project/myproject123/dataset/d1/table/t1$20171001')
         self.assertEqual(tasks[1].url, '/bigQuery/project/myproject123/dataset/d1/table/t1$20171002')

--- a/tests/bigquery_handler_test.py
+++ b/tests/bigquery_handler_test.py
@@ -12,6 +12,8 @@ from gcp_census import routes
 from gcp_census.bigquery.bigquery_client import BigQuery
 from gcp_census.bigquery.transformers.table_metadata_v0_1 import \
     TableMetadataV0_1
+from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
+    TableMetadataV1_0
 
 response404 = Response({"status": 404, "reason": "Table Not found"})
 response500 = Response({"status": 500, "reason": "Internal error"})
@@ -230,8 +232,9 @@ class TestGcpMetadataHandler(unittest.TestCase):
     @patch.object(BigQuery, 'get_table', return_value=example_table)
     @patch.object(BigQuery, 'stream_stats')
     @patch.object(TableMetadataV0_1, 'transform')
+    @patch.object(TableMetadataV1_0, 'transform')
     def test_streaming_table_metadata(
-            self, _, stream_stats, get_table
+            self, _, _1, stream_stats, get_table
     ):
         # given
 
@@ -242,4 +245,5 @@ class TestGcpMetadataHandler(unittest.TestCase):
         # then
         get_table.assert_called_once_with('myproject123', 'd1', 't1',
                                           log_table=False)
-        stream_stats.assert_called_once()
+        self.assertEqual(stream_stats.call_count, 2)
+

--- a/tests/bigquery_handler_test.py
+++ b/tests/bigquery_handler_test.py
@@ -243,7 +243,6 @@ class TestGcpMetadataHandler(unittest.TestCase):
                             'table/t1')
 
         # then
-        get_table.assert_called_once_with('myproject123', 'd1', 't1',
-                                          log_table=False)
+        get_table.assert_called_once_with('myproject123', 'd1', 't1')
         self.assertEqual(stream_stats.call_count, 2)
 

--- a/tests/bigquery_table_metadata_test.py
+++ b/tests/bigquery_table_metadata_test.py
@@ -5,7 +5,7 @@ from gcp_census.bigquery.bigquery_table_metadata import BigQueryTableMetadata
 
 class TestBigQueryTableMetadata(unittest.TestCase):
 
-    def test_should_return_False_if_is_a_partition(self):
+    def test_is_daily_partitioned_should_return_False_if_is_a_partition(self):
         # given
         big_query_table_metadata = BigQueryTableMetadata(
             {"tableReference":
@@ -18,7 +18,7 @@ class TestBigQueryTableMetadata(unittest.TestCase):
         # then
         self.assertEqual(False, result)
 
-    def test_should_return_False_if_there_is_no_partitioning_field(self):
+    def test_is_daily_partitioned_should_return_False_if_there_is_no_partitioning_field(self):
         # given
         big_query_table_metadata = BigQueryTableMetadata({})
         # when
@@ -26,7 +26,7 @@ class TestBigQueryTableMetadata(unittest.TestCase):
         # then
         self.assertEqual(False, result)
 
-    def test_should_return_True_if_there_is_DAY_type_in_timePartitioning_field(
+    def test_is_daily_partitioned_should_return_True_if_there_is_DAY_type_in_timePartitioning_field(
             self
     ):
         # given
@@ -39,7 +39,7 @@ class TestBigQueryTableMetadata(unittest.TestCase):
         # then
         self.assertEqual(True, result)
 
-    def test_should_return_False_if_no_metadata_for_table(
+    def test_is_daily_partitioned_should_return_False_if_no_metadata_for_table(
             self
     ):
         # given
@@ -48,3 +48,86 @@ class TestBigQueryTableMetadata(unittest.TestCase):
         result = big_query_table_metadata.is_daily_partitioned()
         # then
         self.assertEqual(False, result)
+
+    def test_is_partition_should_return_true_for_partition(self):
+        # given
+        big_query_table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1$20171002"
+            }
+        })
+        # when
+        result = big_query_table_metadata.is_partition()
+        # then
+        self.assertEqual(True, result)
+
+    def test_is_partition_should_return_false_for_table(self):
+        # given
+        big_query_table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1"
+            }
+        })
+        # when
+        result = big_query_table_metadata.is_partition()
+        # then
+        self.assertEqual(False, result)
+
+    def test_get_partition_id_should_return_partition_id(self):
+        # given
+        big_query_table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1$20171002"
+            }
+        })
+        # when
+        result = big_query_table_metadata.get_partition_id()
+        # then
+        self.assertEqual("20171002", result)
+
+    def test_get_partition_id_should_raise_exception_for_tables(self):
+        # given
+        big_query_table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1"
+            }
+        })
+        # when then
+        with self.assertRaises(AssertionError):
+            big_query_table_metadata.get_partition_id()
+
+    def test_get_table_id_should_return_table_id_when_partition(self):
+        # given
+        big_query_table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1$20171002"
+            }
+        })
+        # when
+        result = big_query_table_metadata.get_table_id()
+        # then
+        self.assertEqual("t1", result)
+
+    def test_get_table_id_should_return_table_id_when_not_partitioned(self):
+        # given
+        big_query_table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1"
+            }
+        })
+        # when
+        result = big_query_table_metadata.get_table_id()
+        # then
+        self.assertEqual("t1", result)

--- a/tests/bigquery_table_streamer_test.py
+++ b/tests/bigquery_table_streamer_test.py
@@ -1,0 +1,72 @@
+import unittest
+from mock import patch
+
+from gcp_census.bigquery.bigquery_client import BigQuery
+from gcp_census.bigquery.bigquery_table_metadata import BigQueryTableMetadata
+from gcp_census.bigquery.bigquery_table_streamer import BigQueryTableStreamer
+from gcp_census.bigquery.transformers.partition_metadata_v1_0 import \
+    PartitionMetadataV1_0
+from gcp_census.bigquery.transformers.table_metadata_v0_1 import \
+    TableMetadataV0_1
+from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
+    TableMetadataV1_0
+
+
+class TestBigQueryTableStreamer(unittest.TestCase):
+    def setUp(self):
+        patch('googleapiclient.discovery.build').start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch.object(TableMetadataV0_1, 'transform')
+    @patch.object(TableMetadataV1_0, 'transform')
+    @patch.object(PartitionMetadataV1_0, 'transform')
+    @patch.object(BigQuery, '_stream_metadata')
+    def test_should_stream_partition_table_to_v1_tables_only(self,
+                                                             _,
+                                                             partition_v1_0,
+                                                             table_v1_0,
+                                                             table_v0_1):
+        # given
+        table_streamer = BigQueryTableStreamer(BigQuery())
+        table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1$20171002"
+            }
+        })
+
+        # when
+        table_streamer.stream_metadata(table_metadata, [])
+        # then
+        table_v0_1.assert_not_called()
+        table_v1_0.assert_not_called()
+        partition_v1_0.assert_called_once()
+
+    @patch.object(TableMetadataV0_1, 'transform')
+    @patch.object(TableMetadataV1_0, 'transform')
+    @patch.object(PartitionMetadataV1_0, 'transform')
+    @patch.object(BigQuery, '_stream_metadata')
+    def test_should_stream_table_to_v1_tables_only(self,
+                                                             _,
+                                                             partition_v1_0,
+                                                             table_v1_0,
+                                                             table_v0_1):
+        # given
+        table_streamer = BigQueryTableStreamer(BigQuery())
+        table_metadata = BigQueryTableMetadata({
+            "tableReference": {
+                "projectId": "p1",
+                "datasetId": "d1",
+                "tableId": "t1"
+            }
+        })
+
+        # when
+        table_streamer.stream_metadata(table_metadata, [])
+        # then
+        table_v0_1.assert_called_once()
+        table_v1_0.assert_called_once()
+        partition_v1_0.assert_not_called()

--- a/tests/bigquery_transformer_partition_metadata_v1_0_test.py
+++ b/tests/bigquery_transformer_partition_metadata_v1_0_test.py
@@ -1,21 +1,21 @@
 import unittest
 
 from gcp_census.bigquery.bigquery_table_metadata import BigQueryTableMetadata
-from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
-    TableMetadataV1_0
+from gcp_census.bigquery.transformers.partition_metadata_v1_0 import \
+    PartitionMetadataV1_0
 
 
-class TestTableMetadataV1_0(unittest.TestCase):
+class TestPartitionMetadataV1_0(unittest.TestCase):
     def test_transforming_table_without_labels(self):
         # given
         table = {
             'kind': 'bigquery#table',
             'etag': '\'smpMas70-D1-zV2oEH0ud6qY21c/MTQ2ODQxNDY2MDU3Mg\'',
-            'id': 'dev-manager:crm_raw.account_1_0_0_20150603',
+            'id': 'dev-manager:crm_raw.account_1_0_0$20150603',
             'tableReference': {
                 'projectId': 'dev-manager',
                 'datasetId': 'crm_raw',
-                'tableId': 'account_1_0_0_20150603'
+                'tableId': 'account_1_0_0$20150603'
             },
             "description": "secs\n\njhbhgvhgv\n\nlorem",
             'numBytes': '421940',
@@ -28,8 +28,8 @@ class TestTableMetadataV1_0(unittest.TestCase):
         }
 
         # when
-        data = TableMetadataV1_0(BigQueryTableMetadata(table)).transform()
+        data = PartitionMetadataV1_0(BigQueryTableMetadata(table)).transform()
 
         # then
-        self.assertEqual('account_1_0_0_20150603', data['tableId'])
-        self.assertEqual(0, len(data['labels']))
+        self.assertEqual('account_1_0_0', data['tableId'])
+        self.assertEqual('20150603', data['partitionId'])

--- a/tests/bigquery_transformer_table_metadata_v0_1_test.py
+++ b/tests/bigquery_transformer_table_metadata_v0_1_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from gcp_census.bigquery.bigquery_table_metadata import BigQueryTableMetadata
 from gcp_census.bigquery.transformers.table_metadata_v0_1 import \
     TableMetadataV0_1
 
@@ -10,9 +11,9 @@ class TestTableMetadataV0_1(unittest.TestCase):
         table = {
             'kind': 'bigquery#table',
             'etag': '\'smpMas70-D1-zV2oEH0ud6qY21c/MTQ2ODQxNDY2MDU3Mg\'',
-            'id': 'sit-atm-eu-datamanager:crm_raw.account_1_0_0_20150603',
+            'id': 'dev-manager:crm_raw.account_1_0_0_20150603',
             'tableReference': {
-                'projectId': 'sit-atm-eu-datamanager',
+                'projectId': 'dev-manager',
                 'datasetId': 'crm_raw',
                 'tableId': 'account_1_0_0_20150603'
             },
@@ -27,7 +28,7 @@ class TestTableMetadataV0_1(unittest.TestCase):
         }
 
         # when
-        data = TableMetadataV0_1(table).transform()
+        data = TableMetadataV0_1(BigQueryTableMetadata(table)).transform()
 
         # then
         self.assertEqual('account_1_0_0_20150603', data['tableId'])
@@ -38,9 +39,9 @@ class TestTableMetadataV0_1(unittest.TestCase):
         table = {
             'kind': 'bigquery#table',
             'etag': '\'smpMas70-D1-zV2oEH0ud6qY21c/MTQ2ODQxNDY2MDU3Mg\'',
-            'id': 'sit-atm-eu-datamanager:crm_raw.account_1_0_0_20150603',
+            'id': 'dev-manager:crm_raw.account_1_0_0_20150603',
             'tableReference': {
-                'projectId': 'sit-atm-eu-datamanager',
+                'projectId': 'dev-manager',
                 'datasetId': 'crm_raw',
                 'tableId': 'account_1_0_0_20150603'
             },
@@ -60,7 +61,7 @@ class TestTableMetadataV0_1(unittest.TestCase):
         }
 
         # when
-        data = TableMetadataV0_1(table).transform()
+        data = TableMetadataV0_1(BigQueryTableMetadata(table)).transform()
 
         # then
         self.assertEqual(3, len(data['labels']))

--- a/tests/bigquery_transformer_table_metadata_v0_1_test.py
+++ b/tests/bigquery_transformer_table_metadata_v0_1_test.py
@@ -1,12 +1,10 @@
 import unittest
 
-from gcp_census.bigquery.bigquery_table_metadata import BigQueryTableMetadata
 from gcp_census.bigquery.transformers.table_metadata_v0_1 import \
     TableMetadataV0_1
 
 
 class TestTableMetadataV0_1(unittest.TestCase):
-
     def test_transforming_table_without_labels(self):
         # given
         table = {
@@ -29,11 +27,11 @@ class TestTableMetadataV0_1(unittest.TestCase):
         }
 
         # when
-        row = TableMetadataV0_1(BigQueryTableMetadata(table)).transform()
+        data = TableMetadataV0_1(table).transform()
 
         # then
-        self.assertEqual('account_1_0_0_20150603', row.data['tableId'])
-        self.assertEqual(0, len(row.data['labels']))
+        self.assertEqual('account_1_0_0_20150603', data['tableId'])
+        self.assertEqual(0, len(data['labels']))
 
     def test_transforming_table_with_labels(self):
         # given
@@ -62,9 +60,9 @@ class TestTableMetadataV0_1(unittest.TestCase):
         }
 
         # when
-        row = TableMetadataV0_1(BigQueryTableMetadata(table)).transform()
+        data = TableMetadataV0_1(table).transform()
 
         # then
-        self.assertEqual(3, len(row.data['labels']))
-        self.assertEqual(row.data['labels'][0]['key'], 'key3')
-        self.assertEqual(row.data['labels'][0]['value'], 'value3')
+        self.assertEqual(3, len(data['labels']))
+        self.assertEqual(data['labels'][0]['key'], 'key3')
+        self.assertEqual(data['labels'][0]['value'], 'value3')

--- a/tests/bigquery_transformer_table_metadata_v1_0_test.py
+++ b/tests/bigquery_transformer_table_metadata_v1_0_test.py
@@ -1,0 +1,34 @@
+import unittest
+
+from gcp_census.bigquery.transformers.table_metadata_v1_0 import \
+    TableMetadataV1_0
+
+
+class TestTableMetadataV1_0(unittest.TestCase):
+    def test_transforming_table_without_labels(self):
+        # given
+        table = {
+            'kind': 'bigquery#table',
+            'etag': '\'smpMas70-D1-zV2oEH0ud6qY21c/MTQ2ODQxNDY2MDU3Mg\'',
+            'id': 'sit-atm-eu-datamanager:crm_raw.account_1_0_0_20150603',
+            'tableReference': {
+                'projectId': 'sit-atm-eu-datamanager',
+                'datasetId': 'crm_raw',
+                'tableId': 'account_1_0_0_20150603'
+            },
+            "description": "secs\n\njhbhgvhgv\n\nlorem",
+            'numBytes': '421940',
+            'numLongTermBytes': '421940',
+            'numRows': '1445',
+            'creationTime': '1468414660572',
+            'lastModifiedTime': '1468414660572',
+            'type': 'TABLE',
+            'location': 'US'
+        }
+
+        # when
+        data = TableMetadataV1_0(table).transform()
+
+        # then
+        self.assertEqual('account_1_0_0_20150603', data['tableId'])
+        self.assertEqual(0, len(data['labels']))

--- a/tests/model_creator_test.py
+++ b/tests/model_creator_test.py
@@ -86,6 +86,8 @@ class TestModelCreator(unittest.TestCase):
             ({'status': '200'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_test_schema.json')),
             ({'status': '200'}, test_utils.content(
+                'tests/json_samples/bigquery_v2_tables_insert_200.json')),
+            ({'status': '200'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_tables_insert_200.json'))
         ]))
         _create_http.return_value = http_mock
@@ -96,7 +98,7 @@ class TestModelCreator(unittest.TestCase):
 
         # then
         calls = http_mock.mock_calls
-        self.assertEqual(2, len(calls))
+        self.assertEqual(3, len(calls))
 
     @patch.object(ModelCreator, '_create_http')
     def test_should_ignore_table_already_exists_error(self, _create_http):
@@ -104,6 +106,8 @@ class TestModelCreator(unittest.TestCase):
         http_mock = Mock(wraps=HttpMockSequence([
             ({'status': '200'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_test_schema.json')),
+            ({'status': '409'}, test_utils.content(
+                'tests/json_samples/bigquery_v2_tables_insert_409.json')),
             ({'status': '409'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_tables_insert_409.json'))
         ]))
@@ -115,7 +119,7 @@ class TestModelCreator(unittest.TestCase):
 
         # then
         calls = http_mock.mock_calls
-        self.assertEqual(2, len(calls))
+        self.assertEqual(3, len(calls))
 
     @patch.object(ModelCreator, '_create_http')
     def test_should_propagate_table_500_error(self, _create_http):

--- a/tests/model_creator_test.py
+++ b/tests/model_creator_test.py
@@ -2,12 +2,11 @@ import unittest
 
 from apiclient.errors import HttpError
 from apiclient.http import HttpMockSequence
-
 from google.appengine.ext import testbed
 from mock import patch, Mock
 
-from gcp_census.model.model_creator import ModelCreator
 import test_utils
+from gcp_census.model.model_creator import ModelCreator
 
 
 class TestModelCreator(unittest.TestCase):
@@ -88,6 +87,8 @@ class TestModelCreator(unittest.TestCase):
             ({'status': '200'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_tables_insert_200.json')),
             ({'status': '200'}, test_utils.content(
+                'tests/json_samples/bigquery_v2_tables_insert_200.json')),
+            ({'status': '200'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_tables_insert_200.json'))
         ]))
         _create_http.return_value = http_mock
@@ -98,7 +99,7 @@ class TestModelCreator(unittest.TestCase):
 
         # then
         calls = http_mock.mock_calls
-        self.assertEqual(3, len(calls))
+        self.assertEqual(4, len(calls))
 
     @patch.object(ModelCreator, '_create_http')
     def test_should_ignore_table_already_exists_error(self, _create_http):
@@ -106,6 +107,8 @@ class TestModelCreator(unittest.TestCase):
         http_mock = Mock(wraps=HttpMockSequence([
             ({'status': '200'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_test_schema.json')),
+            ({'status': '409'}, test_utils.content(
+                'tests/json_samples/bigquery_v2_tables_insert_409.json')),
             ({'status': '409'}, test_utils.content(
                 'tests/json_samples/bigquery_v2_tables_insert_409.json')),
             ({'status': '409'}, test_utils.content(
@@ -119,7 +122,7 @@ class TestModelCreator(unittest.TestCase):
 
         # then
         calls = http_mock.mock_calls
-        self.assertEqual(3, len(calls))
+        self.assertEqual(4, len(calls))
 
     @patch.object(ModelCreator, '_create_http')
     def test_should_propagate_table_500_error(self, _create_http):


### PR DESCRIPTION
Fixes #6 and #12. Partitions metadata is now streamed into a separate table partition_metadata_v1_0, table metadata goes both to table_metadata_v0_1 and table_metadata_v1_0.